### PR TITLE
Add debian package creation to release.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ contain the submodule sourece code. To obtain the full sources:
   and a `.tgz` or `.md5` extension respectively. The host binaries
   therein are stripped.
 
+  Supplying the `--debian` option additionally builds a `.deb` Debian package.
+  The Debian control metadata automatically infers the system architecture (e.g., amd64, arm64)
+  and package version from Git tags.
+
 5) Making the release available (from github)
 
   Upload the tarball and md5 hash as a binary file added to a git

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,6 +47,8 @@ if $debian; then
 ARCH=$(dpkg --print-architecture)
 VERSION=$(git describe --tags --always | sed 's/^v//; s/-/~/g')
 
+echo "INFO: Creating Debian package for architecture: $ARCH with version: $VERSION"
+
 # Create Debian package structure
 PKGDIR="$BUILD/sfpi-deb"
 DEBIAN="$PKGDIR/DEBIAN"
@@ -75,5 +77,5 @@ EOF
 # Build the .deb package
 dpkg-deb --build "$PKGDIR" "$BUILD/$IDENT.deb"
 
-echo "Debian package created at: $BUILD/$IDENT.deb"
+echo "INFO: Debian package created at: $BUILD/$IDENT.deb"
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -37,3 +37,32 @@ find $BUILD/sfpi/compiler -type f -executable -exec file {} \; | \
 
 (cd $BUILD ; tar czf sfpi-release.tgz sfpi)
 md5sum $BUILD/sfpi-release.tgz > $BUILD/sfpi.md5
+
+# Create Debian package structure
+PKGDIR="$BUILD/sfpi-deb"
+DEBIAN="$PKGDIR/DEBIAN"
+INSTALL_DIR="$PKGDIR/opt/tenstorrent/sfpi"
+
+rm -rf "$PKGDIR"
+mkdir -p "$DEBIAN" "$INSTALL_DIR"
+
+# Extract the release tgz into the installation directory
+tar -xzf "$BUILD/sfpi-release.tgz" -C "$PKGDIR/opt/tenstorrent"
+
+# Create a control file for the package
+cat > "$DEBIAN/control" <<EOF
+Package: sfpi
+Version: 1.0.0
+Section: base
+Priority: optional
+Architecture: amd64
+Maintainer: Tenstorrent <support@tenstorrent.com>
+Depends: libgmp10 (>= 2:6.2.1), libmpfr6 (>= 4.1.0), libmpc3 (>= 1.2.1)
+Description: Tenstorrent SFPI Release
+ This package installs the sfpi release to /opt/tenstorrent/sfpi
+EOF
+
+# Build the .deb package
+dpkg-deb --build "$PKGDIR" "$BUILD/sfpi.deb"
+
+echo "Debian package created at: $BUILD/sfpi.deb"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,6 +43,10 @@ IDENT=sfpi-$(uname -m)-$(uname -s)
 md5sum $BUILD/$IDENT.tgz > $BUILD/$IDENT.md5
 
 if $debian; then
+
+ARCH=$(dpkg --print-architecture)
+VERSION=$(git describe --tags --always | sed 's/^v//; s/-/~/g')
+
 # Create Debian package structure
 PKGDIR="$BUILD/sfpi-deb"
 DEBIAN="$PKGDIR/DEBIAN"
@@ -57,10 +61,10 @@ tar -xzf "$BUILD/$IDENT.tgz" -C "$PKGDIR/opt/tenstorrent"
 # Create a control file for the package
 cat > "$DEBIAN/control" <<EOF
 Package: sfpi
-Version: 1.0.0
+Version: $VERSION
 Section: base
 Priority: optional
-Architecture: amd64
+Architecture: $ARCH
 Maintainer: Tenstorrent <support@tenstorrent.com>
 Homepage: https://github.com/tenstorrent/sfpi
 Depends: libgmp10 (>= 2:6.2.1), libmpfr6 (>= 4.1.0), libmpc3 (>= 1.2.1)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,6 +57,7 @@ Section: base
 Priority: optional
 Architecture: amd64
 Maintainer: Tenstorrent <support@tenstorrent.com>
+Homepage: https://github.com/tenstorrent/sfpi
 Depends: libgmp10 (>= 2:6.2.1), libmpfr6 (>= 4.1.0), libmpc3 (>= 1.2.1)
 Description: Tenstorrent SFPI Release
  This package installs the sfpi release to /opt/tenstorrent/sfpi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,10 +10,12 @@ fi
 
 BUILD=build
 force=false
+debian=false
 while [ "$#" -ne 0 ] ; do
     case "$1" in
 	--dir=*) BUILD="${1#*=}" ;;
 	--force) force=true ;;
+        --debian) debian=true ;;
 	-*) echo "Unknown option '$1'" >&2 ; exit 2 ;;
 	*) break ;;
     esac
@@ -40,6 +42,7 @@ IDENT=sfpi-$(uname -m)-$(uname -s)
 (cd $BUILD ; tar czf $IDENT.tgz sfpi)
 md5sum $BUILD/$IDENT.tgz > $BUILD/$IDENT.md5
 
+if $debian; then
 # Create Debian package structure
 PKGDIR="$BUILD/sfpi-deb"
 DEBIAN="$PKGDIR/DEBIAN"
@@ -69,3 +72,4 @@ EOF
 dpkg-deb --build "$PKGDIR" "$BUILD/$IDENT.deb"
 
 echo "Debian package created at: $BUILD/$IDENT.deb"
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,24 +44,24 @@ md5sum $BUILD/$IDENT.tgz > $BUILD/$IDENT.md5
 
 if $debian; then
 
-ARCH=$(dpkg --print-architecture)
-VERSION=$(git describe --tags --always | sed 's/^v//; s/-/~/g')
+    ARCH=$(dpkg --print-architecture)
+    VERSION=$(git describe --tags --always | sed 's/^v//; s/-/~/g')
 
-echo "INFO: Creating Debian package for architecture: $ARCH with version: $VERSION"
+    echo "INFO: Creating Debian package for architecture: $ARCH with version: $VERSION"
 
-# Create Debian package structure
-PKGDIR="$BUILD/sfpi-deb"
-DEBIAN="$PKGDIR/DEBIAN"
-INSTALL_DIR="$PKGDIR/opt/tenstorrent/sfpi"
+    # Create Debian package structure
+    PKGDIR="$BUILD/sfpi-deb"
+    DEBIAN="$PKGDIR/DEBIAN"
+    INSTALL_DIR="$PKGDIR/opt/tenstorrent/sfpi"
 
-rm -rf "$PKGDIR"
-mkdir -p "$DEBIAN" "$INSTALL_DIR"
+    rm -rf "$PKGDIR"
+    mkdir -p "$DEBIAN" "$INSTALL_DIR"
 
-# Extract the release tgz into the installation directory
-tar -xzf "$BUILD/$IDENT.tgz" -C "$PKGDIR/opt/tenstorrent"
+    # Extract the release tgz into the installation directory
+    tar -xzf "$BUILD/$IDENT.tgz" -C "$PKGDIR/opt/tenstorrent"
 
-# Create a control file for the package
-cat > "$DEBIAN/control" <<EOF
+    # Create a control file for the package
+    cat > "$DEBIAN/control" <<EOF
 Package: sfpi
 Version: $VERSION
 Section: base
@@ -74,8 +74,8 @@ Description: Tenstorrent SFPI Release
  This package installs the sfpi release to /opt/tenstorrent/sfpi
 EOF
 
-# Build the .deb package
-dpkg-deb --build "$PKGDIR" "$BUILD/$IDENT.deb"
+    # Build the .deb package
+    dpkg-deb --build "$PKGDIR" "$BUILD/$IDENT.deb"
 
-echo "INFO: Debian package created at: $BUILD/$IDENT.deb"
+    echo "INFO: Debian package created at: $BUILD/$IDENT.deb"
 fi


### PR DESCRIPTION
We have things in place to always download the sfpi compiler release into either the python site-packages or the current working directory.

Lets have the option to install it as a system package.

When installed from a debian, it will install to /opt/tenstorrent/sfpi/

I tested, and this works.

The debian package version could use some massage.