### PR TITLE
MacOS and Picolibc cross-compilation experiments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/tenstorrent/sfpi-binutils.git
 [submodule "gcc"]
 	path = gcc
-	url = https://github.com/tenstorrent/sfpi-gcc.git
+	url = https://github.com/tmagik/sfpi-gcc.git
 [submodule "newlib"]
 	path = newlib
 	url = https://sourceware.org/git/newlib-cygwin.git

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ if ! test "$BIN" -ef "scripts"; then
     exit 1
 fi
 
-NCPUS=$(grep -c '^processor' /proc/cpuinfo)
+NCPUS=$(nproc)
 if ! test "$NCPUS" ; then
     NCPUS=1
 fi
@@ -94,7 +94,7 @@ if ! test -e $BUILD/Makefile ; then
      ../configure --prefix="$(pwd)/sfpi/compiler" "${ident_options[@]}" \
 		  --enable-gcc-checking="$gcc_checking" \
 		  "$multilib" \
-		  --with-arch=rv32i --with-abi=ilp32 --enable-gdb)
+		  --with-arch=rv32i --with-abi=ilp32 --disable-gdb)
 fi
 
 # build the toolchain


### PR DESCRIPTION
This is an attempt to support cross-compilation of tt-sfpi-gcc from a MacOS host, and evaluate replacing newlib with picolibc.