### PR TITLE
Add __builtin_rvtt_sfp{mul,add}i.

### DIFF
--- a/include/blackhole/sfpi_hw.h
+++ b/include/blackhole/sfpi_hw.h
@@ -48,6 +48,9 @@ namespace sfpi {
 #define __builtin_rvtt_sfpmul(va, vb, mod1) sfpu_rvtt_sfpmul(va, vb, mod1)
 #define __builtin_rvtt_sfpmad(va, vb, vc, mod1) sfpu_rvtt_sfpmad(va, vb, vc, mod1)
 
+#define __builtin_rvtt_sfpmuli(v, imm, mod1) sfpu_rvtt_sfpmuli(v, imm, mod1)
+#define __builtin_rvtt_sfpaddi(v, imm, mod1) sfpu_rvtt_sfpaddi(v, imm, mod1)
+
 #define __builtin_rvtt_sfpexexp(src, mod1) sfpu_rvtt_sfpexexp(src, mod1)
 #define __builtin_rvtt_sfpexman(src, mod1) sfpu_rvtt_sfpexman(src, mod1)
 

--- a/include/wormhole/sfpi_hw.h
+++ b/include/wormhole/sfpi_hw.h
@@ -48,6 +48,9 @@ namespace sfpi {
 #define __builtin_rvtt_sfpmul(va, vb, mod1) sfpu_rvtt_sfpmul(va, vb, mod1)
 #define __builtin_rvtt_sfpmad(va, vb, vc, mod1) sfpu_rvtt_sfpmad(va, vb, vc, mod1)
 
+#define __builtin_rvtt_sfpmuli(v, imm, mod1) sfpu_rvtt_sfpmuli(v, imm, mod1)
+#define __builtin_rvtt_sfpaddi(v, imm, mod1) sfpu_rvtt_sfpaddi(v, imm, mod1)
+
 #define __builtin_rvtt_sfpexexp(src, mod1) sfpu_rvtt_sfpexexp(src, mod1)
 #define __builtin_rvtt_sfpexman(src, mod1) sfpu_rvtt_sfpexman(src, mod1)
 


### PR DESCRIPTION
I noticed that SFPI codegen doesn't seem to use `SFPMULI` e.g. in this simple case on BH:

```c
sfpi::vFloat y = 0.5f * x;
```

The `0.5f` value can be trivially represented as a BF16 immediate.

Is there a reason issues are disabled on this repo?  Opening this PR as a way to raise discussion @nathan-TT 