### PR TITLE
Add version to released package name

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -52,7 +52,7 @@ tar cf - include | tar xf - -C $BUILD/sfpi
 find $BUILD/sfpi/compiler -type f -executable -exec file {} \; | \
     grep '^[^ ]*:  *ELF 64-bit ' | cut -d: -f1 | xargs strip -g
 
-NAME=sfpi-$(uname -m)_$(uname -s)
+NAME=sfpi-$(uname -m)_$(uname -s)_${tt_version}
 
 # whether we can build a particular package type
 mkdeb=true


### PR DESCRIPTION
To differentiate versions when having multiple versions in the same folder (necessary for PPA packaging), we must append the version name to the created .deb. I _think_ this is the way to do that, but if I'm missing something in the release flow, let me know.