### PR TITLE
replaced /bin/bash with /usr/bin/env bash to improve portability

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 BIN="$(dirname "$0")"

--- a/scripts/git-hash.sh
+++ b/scripts/git-hash.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -e
 version="$1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 BIN="$(dirname "$0")"

--- a/scripts/riscv-tt-elf-run
+++ b/scripts/riscv-tt-elf-run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 qemu_args=()
 while [[ "$1" != "" ]]

--- a/scripts/sfpi-info.sh
+++ b/scripts/sfpi-info.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # Compute SFPI release version information.
 # Emit as evaluable shell assignments or CMAKE script


### PR DESCRIPTION
when building [tt-llk tests](https://github.com/tenstorrent/tt-llk/tree/main/tests) on nixos it might need to build and release sfpi in [sfpi-info.sh](https://github.com/tenstorrent/tt-llk/blob/c10e7fc74ab40d0bc24ff73fbad4ee91bb9cc187/tests/sfpi-info.sh#L202) which is called from [setup_testing_env.sh](https://github.com/tenstorrent/tt-llk/blob/c10e7fc74ab40d0bc24ff73fbad4ee91bb9cc187/tests/setup_testing_env.sh#L206). this will fail on nixos (and other non-fhs systems) because `/bin/bash` doesn't exist. on nixos for example it is installed at `/nix/store/<hash>-bash-<version>/bin/bash`

most of shell scripts in tt-llk tests already use `/usr/bin/env bash`, so this pull request is a proposal to make shell scripts in sfpi repo more portable ☺️